### PR TITLE
Convert tuples set in metadata to a binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ Here's how you would use the included JSON formatter with the
 
 ## Changelog
 
+#### 0.1.4
+
+  * Convert tuples in metadata to a binary before passing it to the
+    JSON encoder. This should solve a crash when processes are named
+    using via-tuples in a process registry like `gproc`.
+
 #### 0.1.3
 
   * Small fixes

--- a/src/lager_logstash_json_formatter.erl
+++ b/src/lager_logstash_json_formatter.erl
@@ -41,7 +41,12 @@ format(LagerMsg, #{ json_encoder := Encoder, tag := T }) ->
 
 timestamp({Date, Time}) -> [Date, $T, Time].
 
-convert_metadata(M) -> M.
+convert_metadata(L) ->
+    [do_convert_metadata(M) || M <- L].
+
+do_convert_metadata({Key, Value}) when is_tuple(Value) ->
+    {Key, iolist_to_binary(io_lib:format("~p", [Value]))};
+do_convert_metadata(M) -> M.
 
 convert(Data) -> lists:foldl(fun convert/2, [], Data).
 


### PR DESCRIPTION
When a process is registered in a process registry using via-tuples this part of the code would fail because the JSON-encoder would throw an error. This patch make sure the tuples are converted into a binary before it is passed on to the JSON encoder.